### PR TITLE
fixed one bug in resposive navbar dropdown

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import LandingPage from "./components/LandingPage";
 
 
 
+
 import {
   BrowserRouter as Router,
   Routes,

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -8,6 +8,16 @@ import {SiGmail} from 'react-icons/si'
 import { Link } from "react-router-dom";
 
 function Navbar() {
+  
+  const change=()=>{
+    if(window.location.pathname==='/'){
+      window.location.pathname="/#"
+    }
+    else if(window.location.pathname==='/team'){
+      window.location.pathname="/team"
+    }
+  }
+
 
   const menuBtn = useRef(null)
   
@@ -37,7 +47,7 @@ function Navbar() {
         <a href='/#' className='topnav-link'>Lensation</a>
         <Link to='/team' className='topnav-link'>Team</Link>
         <a href='/#' className='topnav-link'>Work</a>
-        <a href='/#' className='dropdown-nav icon' onClick={handleClick} >   {/* here bug is there the href should change according the webpage we visit or else it will always go on '/#'*/}
+        <a href={change} className='dropdown-nav icon' onClick={handleClick} >   
             <FiMenu size={20}/>
         </a>
 


### PR DESCRIPTION
There was a bug in resposive navbar initially you are on events page the path is "localhost:3000/#" but when we go to teams page it is "localhost:3000/team"  but when you are on teams page and click on dropdown icon to make the dropdown disappear  it goes to "localhost:3000/#" again rather than staying on "localhost:3000/team",so I wrote a function "change" in Navbar.js to resolve that issue using "window.location.pathname".